### PR TITLE
refactor! Rename `operation` classes & methods to `xxxHandler`

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,14 +185,14 @@ Patch application is designed to be atomic. If any operation of a given patch fa
   ```
 
 
-#### `function registerOperation(PatchOperationInterface $PatchOperation): void`
+#### `function registerOperationHandler(PatchOperationHandlerInterface $PatchOperation): void`
 
 - **Description**: Allows to register new patch operation handlers or to override existing ones.
 - **Parameters**:
-  - `PatchOperationInterface $PatchOperation`: The handler class for handling the operation.
+  - `PatchOperationHandlerInterface $PatchOperation`: The handler class for handling the operation.
 - **Example**:
   ```php
-  $FastJsonPatch->registerOperation(new Add);
+  $FastJsonPatch->registerOperationHandler(new Add);
   ```
 
 

--- a/src/FastJsonPatch.php
+++ b/src/FastJsonPatch.php
@@ -23,13 +23,15 @@ use blancks\JsonPatch\json\pointer\{
 };
 use blancks\JsonPatch\operations\{
     PatchOperationInterface,
-    PatchValidationTrait,
-    Add,
-    Copy,
-    Move,
-    Remove,
-    Replace,
-    Test
+    PatchValidationTrait
+};
+use blancks\JsonPatch\operations\handlers\{
+    AddHandler,
+    CopyHandler,
+    MoveHandler,
+    RemoveHandler,
+    ReplaceHandler,
+    TestHandler
 };
 
 /**
@@ -91,12 +93,12 @@ final class FastJsonPatch implements JsonHandlerAwareInterface, JsonPointerHandl
 
         $this->setJsonPointerHandler($JsonPointerHandler);
         $this->setJsonHandler($JsonHandler);
-        $this->registerOperation(new Add);
-        $this->registerOperation(new Copy);
-        $this->registerOperation(new Move);
-        $this->registerOperation(new Remove);
-        $this->registerOperation(new Replace);
-        $this->registerOperation(new Test);
+        $this->registerOperation(new AddHandler);
+        $this->registerOperation(new CopyHandler);
+        $this->registerOperation(new MoveHandler);
+        $this->registerOperation(new RemoveHandler);
+        $this->registerOperation(new ReplaceHandler);
+        $this->registerOperation(new TestHandler);
     }
 
     /**

--- a/src/FastJsonPatch.php
+++ b/src/FastJsonPatch.php
@@ -22,13 +22,13 @@ use blancks\JsonPatch\json\pointer\{
     JsonPointerHandlerInterface
 };
 use blancks\JsonPatch\operations\{
-    PatchOperationInterface,
     PatchValidationTrait
 };
 use blancks\JsonPatch\operations\handlers\{
     AddHandler,
     CopyHandler,
     MoveHandler,
+    PatchOperationHandlerInterface,
     RemoveHandler,
     ReplaceHandler,
     TestHandler
@@ -50,9 +50,9 @@ final class FastJsonPatch implements JsonHandlerAwareInterface, JsonPointerHandl
     private mixed $document;
 
     /**
-     * @var array<string, PatchOperationInterface> registered classes for handling patch operations
+     * @var array<string, PatchOperationHandlerInterface> registered classes for handling patch operations
      */
-    private array $operations = [];
+    private array $operationHandlers = [];
 
     /**
      * Creates a FastJsonPatch instance from a json string document
@@ -93,21 +93,21 @@ final class FastJsonPatch implements JsonHandlerAwareInterface, JsonPointerHandl
 
         $this->setJsonPointerHandler($JsonPointerHandler);
         $this->setJsonHandler($JsonHandler);
-        $this->registerOperation(new AddHandler);
-        $this->registerOperation(new CopyHandler);
-        $this->registerOperation(new MoveHandler);
-        $this->registerOperation(new RemoveHandler);
-        $this->registerOperation(new ReplaceHandler);
-        $this->registerOperation(new TestHandler);
+        $this->registerOperationHandler(new AddHandler);
+        $this->registerOperationHandler(new CopyHandler);
+        $this->registerOperationHandler(new MoveHandler);
+        $this->registerOperationHandler(new RemoveHandler);
+        $this->registerOperationHandler(new ReplaceHandler);
+        $this->registerOperationHandler(new TestHandler);
     }
 
     /**
      * Allows to register a class that will be responsible to handle a specific patch operation.
      * You can replace a handler class for a given operation or register handlers for custom patch operations
-     * @param PatchOperationInterface $PatchOperation
+     * @param PatchOperationHandlerInterface $PatchOperation
      * @return void
      */
-    public function registerOperation(PatchOperationInterface $PatchOperation): void
+    public function registerOperationHandler(PatchOperationHandlerInterface $PatchOperation): void
     {
         if ($PatchOperation instanceof JsonHandlerAwareInterface) {
             $PatchOperation->setJsonHandler($this->JsonHandler);
@@ -117,7 +117,7 @@ final class FastJsonPatch implements JsonHandlerAwareInterface, JsonPointerHandl
             $PatchOperation->setJsonPointerHandler($this->JsonPointerHandler);
         }
 
-        $this->operations[$PatchOperation->getOperation()] = $PatchOperation;
+        $this->operationHandlers[$PatchOperation->getOperation()] = $PatchOperation;
     }
 
     /**
@@ -134,10 +134,10 @@ final class FastJsonPatch implements JsonHandlerAwareInterface, JsonPointerHandl
             $document = &$this->document;
 
             foreach ($this->patchIterator($patch) as $op => $p) {
-                if (!isset($this->operations[$op])) {
+                if (!isset($this->operationHandlers[$op])) {
                     throw new InvalidPatchOperationException(sprintf('Unknown operation "%s"', $op));
                 }
-                $Operation = $this->operations[$op];
+                $Operation = $this->operationHandlers[$op];
                 $Operation->validate($p);
                 $Operation->apply($document, $p);
                 $revertPatch[] = $Operation->getRevertPatch($p);
@@ -146,7 +146,7 @@ final class FastJsonPatch implements JsonHandlerAwareInterface, JsonPointerHandl
             foreach (array_reverse($revertPatch) as $p) {
                 if (!is_null($p)) {
                     $p = (object) $p;
-                    $this->operations[$p->op]->apply($this->document, $p);
+                    $this->operationHandlers[$p->op]->apply($this->document, $p);
                 }
             }
 
@@ -172,10 +172,10 @@ final class FastJsonPatch implements JsonHandlerAwareInterface, JsonPointerHandl
     {
         try {
             foreach ($this->patchIterator($patch) as $op => $p) {
-                if (!isset($this->operations[$op])) {
+                if (!isset($this->operationHandlers[$op])) {
                     return false;
                 }
-                $this->operations[$op]->validate($p);
+                $this->operationHandlers[$op]->validate($p);
             }
             return true;
         } catch (FastJsonPatchException) {

--- a/src/operations/PatchOperation.php
+++ b/src/operations/PatchOperation.php
@@ -18,12 +18,17 @@ abstract class PatchOperation implements
 
     /**
      * Returns the operation name that the class will handle.
-     * Please note that this method will assume the class short name as the name of the operation,
+     * Please note the default implementation takes this from the lowercased class short name, removing any "Handler"
+     * suffix.
      * feel free to override if this is not the behaviour you want for your operation handler class.
      * @return string
      */
     public function getOperation(): string
     {
-        return strtolower((new \ReflectionClass($this))->getShortName());
+        $name = strtolower((new \ReflectionClass($this))->getShortName());
+        if (str_ends_with($name, 'handler')) {
+            $name = substr($name, 0, -7);
+        }
+        return $name;
     }
 }

--- a/src/operations/handlers/AddHandler.php
+++ b/src/operations/handlers/AddHandler.php
@@ -5,6 +5,9 @@ namespace blancks\JsonPatch\operations\handlers;
 use blancks\JsonPatch\json\accessors\UndefinedValue;
 use blancks\JsonPatch\operations\PatchOperation;
 
+/**
+ * @internal
+ */
 final class AddHandler extends PatchOperation
 {
     private mixed $previous;

--- a/src/operations/handlers/AddHandler.php
+++ b/src/operations/handlers/AddHandler.php
@@ -1,10 +1,11 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatch\operations;
+namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\json\accessors\UndefinedValue;
+use blancks\JsonPatch\operations\PatchOperation;
 
-final class Add extends PatchOperation
+final class AddHandler extends PatchOperation
 {
     private mixed $previous;
 

--- a/src/operations/handlers/AddHandler.php
+++ b/src/operations/handlers/AddHandler.php
@@ -3,12 +3,11 @@
 namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\json\accessors\UndefinedValue;
-use blancks\JsonPatch\operations\PatchOperation;
 
 /**
  * @internal
  */
-final class AddHandler extends PatchOperation
+final class AddHandler extends PatchOperationHandler
 {
     private mixed $previous;
 

--- a/src/operations/handlers/CopyHandler.php
+++ b/src/operations/handlers/CopyHandler.php
@@ -1,10 +1,11 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatch\operations;
+namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\json\accessors\UndefinedValue;
+use blancks\JsonPatch\operations\PatchOperation;
 
-final class Copy extends PatchOperation
+final class CopyHandler extends PatchOperation
 {
     private mixed $previous;
 

--- a/src/operations/handlers/CopyHandler.php
+++ b/src/operations/handlers/CopyHandler.php
@@ -5,6 +5,9 @@ namespace blancks\JsonPatch\operations\handlers;
 use blancks\JsonPatch\json\accessors\UndefinedValue;
 use blancks\JsonPatch\operations\PatchOperation;
 
+/**
+ * @internal
+ */
 final class CopyHandler extends PatchOperation
 {
     private mixed $previous;

--- a/src/operations/handlers/CopyHandler.php
+++ b/src/operations/handlers/CopyHandler.php
@@ -3,12 +3,11 @@
 namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\json\accessors\UndefinedValue;
-use blancks\JsonPatch\operations\PatchOperation;
 
 /**
  * @internal
  */
-final class CopyHandler extends PatchOperation
+final class CopyHandler extends PatchOperationHandler
 {
     private mixed $previous;
 

--- a/src/operations/handlers/MoveHandler.php
+++ b/src/operations/handlers/MoveHandler.php
@@ -2,12 +2,10 @@
 
 namespace blancks\JsonPatch\operations\handlers;
 
-use blancks\JsonPatch\operations\PatchOperation;
-
 /**
  * @internal
  */
-final class MoveHandler extends PatchOperation
+final class MoveHandler extends PatchOperationHandler
 {
     /**
      * @param object{

--- a/src/operations/handlers/MoveHandler.php
+++ b/src/operations/handlers/MoveHandler.php
@@ -4,6 +4,9 @@ namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\operations\PatchOperation;
 
+/**
+ * @internal
+ */
 final class MoveHandler extends PatchOperation
 {
     /**

--- a/src/operations/handlers/MoveHandler.php
+++ b/src/operations/handlers/MoveHandler.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatch\operations;
+namespace blancks\JsonPatch\operations\handlers;
 
-final class Move extends PatchOperation
+use blancks\JsonPatch\operations\PatchOperation;
+
+final class MoveHandler extends PatchOperation
 {
     /**
      * @param object{

--- a/src/operations/handlers/PatchOperationHandler.php
+++ b/src/operations/handlers/PatchOperationHandler.php
@@ -1,14 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatch\operations;
+namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareInterface;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointerHandlerAwareInterface;
 use blancks\JsonPatch\json\pointer\JsonPointerHandlerAwareTrait;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandlerInterface;
+use blancks\JsonPatch\operations\PatchValidationTrait;
 
-abstract class PatchOperation implements
-    PatchOperationInterface,
+abstract class PatchOperationHandler implements
+    PatchOperationHandlerInterface,
     JsonHandlerAwareInterface,
     JsonPointerHandlerAwareInterface
 {

--- a/src/operations/handlers/PatchOperationHandler.php
+++ b/src/operations/handlers/PatchOperationHandler.php
@@ -6,7 +6,6 @@ use blancks\JsonPatch\json\handlers\JsonHandlerAwareInterface;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointerHandlerAwareInterface;
 use blancks\JsonPatch\json\pointer\JsonPointerHandlerAwareTrait;
-use blancks\JsonPatch\operations\handlers\PatchOperationHandlerInterface;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 
 abstract class PatchOperationHandler implements

--- a/src/operations/handlers/PatchOperationHandlerInterface.php
+++ b/src/operations/handlers/PatchOperationHandlerInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatch\operations;
+namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FastJsonPatchException;
 
@@ -9,7 +9,7 @@ use blancks\JsonPatch\exceptions\FastJsonPatchException;
  * handle the patch application for a specific
  * operation type
  */
-interface PatchOperationInterface
+interface PatchOperationHandlerInterface
 {
     /**
      * Must return the operation name that the class will handle

--- a/src/operations/handlers/RemoveHandler.php
+++ b/src/operations/handlers/RemoveHandler.php
@@ -2,12 +2,10 @@
 
 namespace blancks\JsonPatch\operations\handlers;
 
-use blancks\JsonPatch\operations\PatchOperation;
-
 /**
  * @internal
  */
-final class RemoveHandler extends PatchOperation
+final class RemoveHandler extends PatchOperationHandler
 {
     private mixed $previous;
 

--- a/src/operations/handlers/RemoveHandler.php
+++ b/src/operations/handlers/RemoveHandler.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatch\operations;
+namespace blancks\JsonPatch\operations\handlers;
 
-final class Remove extends PatchOperation
+use blancks\JsonPatch\operations\PatchOperation;
+
+final class RemoveHandler extends PatchOperation
 {
     private mixed $previous;
 

--- a/src/operations/handlers/RemoveHandler.php
+++ b/src/operations/handlers/RemoveHandler.php
@@ -4,6 +4,9 @@ namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\operations\PatchOperation;
 
+/**
+ * @internal
+ */
 final class RemoveHandler extends PatchOperation
 {
     private mixed $previous;

--- a/src/operations/handlers/ReplaceHandler.php
+++ b/src/operations/handlers/ReplaceHandler.php
@@ -4,6 +4,9 @@ namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\operations\PatchOperation;
 
+/**
+ * @internal
+ */
 final class ReplaceHandler extends PatchOperation
 {
     private mixed $previous;

--- a/src/operations/handlers/ReplaceHandler.php
+++ b/src/operations/handlers/ReplaceHandler.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatch\operations;
+namespace blancks\JsonPatch\operations\handlers;
 
-final class Replace extends PatchOperation
+use blancks\JsonPatch\operations\PatchOperation;
+
+final class ReplaceHandler extends PatchOperation
 {
     private mixed $previous;
 

--- a/src/operations/handlers/ReplaceHandler.php
+++ b/src/operations/handlers/ReplaceHandler.php
@@ -2,12 +2,10 @@
 
 namespace blancks\JsonPatch\operations\handlers;
 
-use blancks\JsonPatch\operations\PatchOperation;
-
 /**
  * @internal
  */
-final class ReplaceHandler extends PatchOperation
+final class ReplaceHandler extends PatchOperationHandler
 {
     private mixed $previous;
 

--- a/src/operations/handlers/TestHandler.php
+++ b/src/operations/handlers/TestHandler.php
@@ -3,12 +3,11 @@
 namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FailedTestException;
-use blancks\JsonPatch\operations\PatchOperation;
 
 /**
  * @internal
  */
-final class TestHandler extends PatchOperation
+final class TestHandler extends PatchOperationHandler
 {
     /**
      * @param object{

--- a/src/operations/handlers/TestHandler.php
+++ b/src/operations/handlers/TestHandler.php
@@ -5,6 +5,9 @@ namespace blancks\JsonPatch\operations\handlers;
 use blancks\JsonPatch\exceptions\FailedTestException;
 use blancks\JsonPatch\operations\PatchOperation;
 
+/**
+ * @internal
+ */
 final class TestHandler extends PatchOperation
 {
     /**

--- a/src/operations/handlers/TestHandler.php
+++ b/src/operations/handlers/TestHandler.php
@@ -40,7 +40,7 @@ final class TestHandler extends PatchOperationHandler
         if (!$this->isJsonEquals($item, $patch->value)) {
             throw new FailedTestException(
                 sprintf(
-                    'TestHandler operation failed asserting that "%s" equals "%s"',
+                    'Test operation failed asserting that "%s" equals "%s"',
                     $this->JsonHandler->encode($item),
                     $this->JsonHandler->encode($patch->value)
                 ),

--- a/src/operations/handlers/TestHandler.php
+++ b/src/operations/handlers/TestHandler.php
@@ -1,10 +1,11 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatch\operations;
+namespace blancks\JsonPatch\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FailedTestException;
+use blancks\JsonPatch\operations\PatchOperation;
 
-final class Test extends PatchOperation
+final class TestHandler extends PatchOperation
 {
     /**
      * @param object{
@@ -37,7 +38,7 @@ final class Test extends PatchOperation
         if (!$this->isJsonEquals($item, $patch->value)) {
             throw new FailedTestException(
                 sprintf(
-                    'Test operation failed asserting that "%s" equals "%s"',
+                    'TestHandler operation failed asserting that "%s" equals "%s"',
                     $this->JsonHandler->encode($item),
                     $this->JsonHandler->encode($patch->value)
                 ),

--- a/tests/FastJsonPatchTest.php
+++ b/tests/FastJsonPatchTest.php
@@ -22,12 +22,12 @@ use blancks\JsonPatch\json\{
 };
 use blancks\JsonPatch\operations\{
     PatchOperation,
-    Add,
-    Copy,
-    Move,
-    Remove,
-    Replace,
-    Test
+    handlers\AddHandler,
+    handlers\CopyHandler,
+    handlers\MoveHandler,
+    handlers\RemoveHandler,
+    handlers\ReplaceHandler,
+    handlers\TestHandler
 };
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\{
@@ -52,12 +52,12 @@ use PHPUnit\Framework\Attributes\{
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
 #[UsesClass(PatchOperation::class)]
-#[UsesClass(Add::class)]
-#[UsesClass(Copy::class)]
-#[UsesClass(Move::class)]
-#[UsesClass(Remove::class)]
-#[UsesClass(Replace::class)]
-#[UsesClass(Test::class)]
+#[UsesClass(AddHandler::class)]
+#[UsesClass(CopyHandler::class)]
+#[UsesClass(MoveHandler::class)]
+#[UsesClass(RemoveHandler::class)]
+#[UsesClass(ReplaceHandler::class)]
+#[UsesClass(TestHandler::class)]
 final class FastJsonPatchTest extends JsonPatchCompliance
 {
     public function testValidPatch(): void

--- a/tests/FastJsonPatchTest.php
+++ b/tests/FastJsonPatchTest.php
@@ -21,7 +21,7 @@ use blancks\JsonPatch\json\{
     pointer\JsonPointer6901
 };
 use blancks\JsonPatch\operations\{
-    PatchOperation,
+    handlers\PatchOperationHandler,
     handlers\AddHandler,
     handlers\CopyHandler,
     handlers\MoveHandler,
@@ -51,7 +51,7 @@ use PHPUnit\Framework\Attributes\{
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 #[UsesClass(AddHandler::class)]
 #[UsesClass(CopyHandler::class)]
 #[UsesClass(MoveHandler::class)]
@@ -126,7 +126,7 @@ final class FastJsonPatchTest extends JsonPatchCompliance
     public function testCustomOperationHandler(): void
     {
         $FastJsonPatch = FastJsonPatch::fromJson('{}');
-        $FastJsonPatch->registerOperation(new class() extends PatchOperation {
+        $FastJsonPatch->registerOperationHandler(new class() extends PatchOperationHandler {
             public function getOperation(): string
             {
                 return 'addexclamation';

--- a/tests/exceptions/ArrayBoundaryExceptionTest.php
+++ b/tests/exceptions/ArrayBoundaryExceptionTest.php
@@ -12,7 +12,7 @@ use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\Add;
+use blancks\JsonPatch\operations\handlers\AddHandler;
 use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -32,7 +32,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
 #[UsesClass(PatchOperation::class)]
-#[UsesClass(Add::class)]
+#[UsesClass(AddHandler::class)]
 final class ArrayBoundaryExceptionTest extends TestCase
 {
     /**

--- a/tests/exceptions/ArrayBoundaryExceptionTest.php
+++ b/tests/exceptions/ArrayBoundaryExceptionTest.php
@@ -13,7 +13,7 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
 use blancks\JsonPatch\operations\handlers\AddHandler;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 #[UsesClass(AddHandler::class)]
 final class ArrayBoundaryExceptionTest extends TestCase
 {

--- a/tests/exceptions/FailedTestExceptionTest.php
+++ b/tests/exceptions/FailedTestExceptionTest.php
@@ -12,8 +12,8 @@ use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
+use blancks\JsonPatch\operations\handlers\TestHandler;
 use blancks\JsonPatch\operations\PatchOperation;
-use blancks\JsonPatch\operations\Test;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -32,7 +32,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
 #[UsesClass(PatchOperation::class)]
-#[UsesClass(Test::class)]
+#[UsesClass(TestHandler::class)]
 final class FailedTestExceptionTest extends TestCase
 {
     /**

--- a/tests/exceptions/FailedTestExceptionTest.php
+++ b/tests/exceptions/FailedTestExceptionTest.php
@@ -12,8 +12,8 @@ use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\handlers\TestHandler;
-use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 #[UsesClass(TestHandler::class)]
 final class FailedTestExceptionTest extends TestCase
 {

--- a/tests/exceptions/InvalidPatchExceptionTest.php
+++ b/tests/exceptions/InvalidPatchExceptionTest.php
@@ -10,7 +10,7 @@ use blancks\JsonPatch\json\accessors\ObjectAccessorAwareTrait;
 use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ValueAccessorAwareTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 final class InvalidPatchExceptionTest extends TestCase
 {
     /**

--- a/tests/exceptions/InvalidPatchFromExceptionTest.php
+++ b/tests/exceptions/InvalidPatchFromExceptionTest.php
@@ -13,10 +13,10 @@ use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\Add;
-use blancks\JsonPatch\operations\Copy;
+use blancks\JsonPatch\operations\handlers\AddHandler;
+use blancks\JsonPatch\operations\handlers\CopyHandler;
+use blancks\JsonPatch\operations\handlers\RemoveHandler;
 use blancks\JsonPatch\operations\PatchOperation;
-use blancks\JsonPatch\operations\Remove;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -35,9 +35,9 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
 #[UsesClass(PatchOperation::class)]
-#[UsesClass(Add::class)]
-#[UsesClass(Copy::class)]
-#[UsesClass(Remove::class)]
+#[UsesClass(AddHandler::class)]
+#[UsesClass(CopyHandler::class)]
+#[UsesClass(RemoveHandler::class)]
 final class InvalidPatchFromExceptionTest extends TestCase
 {
     /**

--- a/tests/exceptions/InvalidPatchFromExceptionTest.php
+++ b/tests/exceptions/InvalidPatchFromExceptionTest.php
@@ -15,8 +15,8 @@ use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
 use blancks\JsonPatch\operations\handlers\AddHandler;
 use blancks\JsonPatch\operations\handlers\CopyHandler;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\handlers\RemoveHandler;
-use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -34,7 +34,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 #[UsesClass(AddHandler::class)]
 #[UsesClass(CopyHandler::class)]
 #[UsesClass(RemoveHandler::class)]

--- a/tests/exceptions/InvalidPatchOperationExceptionTest.php
+++ b/tests/exceptions/InvalidPatchOperationExceptionTest.php
@@ -11,7 +11,7 @@ use blancks\JsonPatch\json\accessors\ObjectAccessorAwareTrait;
 use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -27,7 +27,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ValueAccessorAwareTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 final class InvalidPatchOperationExceptionTest extends TestCase
 {
     /**

--- a/tests/exceptions/InvalidPatchPathExceptionTest.php
+++ b/tests/exceptions/InvalidPatchPathExceptionTest.php
@@ -11,7 +11,7 @@ use blancks\JsonPatch\json\accessors\ObjectAccessorAwareTrait;
 use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -27,7 +27,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ValueAccessorAwareTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 final class InvalidPatchPathExceptionTest extends TestCase
 {
     /**

--- a/tests/exceptions/InvalidPatchValueExceptionTest.php
+++ b/tests/exceptions/InvalidPatchValueExceptionTest.php
@@ -12,7 +12,7 @@ use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
 use blancks\JsonPatch\operations\handlers\AddHandler;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ValueAccessorAwareTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 #[UsesClass(AddHandler::class)]
 final class InvalidPatchValueExceptionTest extends TestCase
 {

--- a/tests/exceptions/InvalidPatchValueExceptionTest.php
+++ b/tests/exceptions/InvalidPatchValueExceptionTest.php
@@ -11,7 +11,7 @@ use blancks\JsonPatch\json\accessors\ObjectAccessorAwareTrait;
 use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\Add;
+use blancks\JsonPatch\operations\handlers\AddHandler;
 use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
 #[UsesClass(PatchOperation::class)]
-#[UsesClass(Add::class)]
+#[UsesClass(AddHandler::class)]
 final class InvalidPatchValueExceptionTest extends TestCase
 {
     /**

--- a/tests/exceptions/MalformedPathExceptionTest.php
+++ b/tests/exceptions/MalformedPathExceptionTest.php
@@ -11,7 +11,7 @@ use blancks\JsonPatch\json\accessors\ObjectAccessorAwareTrait;
 use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -27,7 +27,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ValueAccessorAwareTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 final class MalformedPathExceptionTest extends TestCase
 {
     /**

--- a/tests/exceptions/UnknownPathExceptionTest.php
+++ b/tests/exceptions/UnknownPathExceptionTest.php
@@ -16,10 +16,10 @@ use blancks\JsonPatch\json\pointer\JsonPointer6901;
 use blancks\JsonPatch\operations\handlers\AddHandler;
 use blancks\JsonPatch\operations\handlers\CopyHandler;
 use blancks\JsonPatch\operations\handlers\MoveHandler;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\handlers\RemoveHandler;
 use blancks\JsonPatch\operations\handlers\ReplaceHandler;
 use blancks\JsonPatch\operations\handlers\TestHandler;
-use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -38,7 +38,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
-#[UsesClass(PatchOperation::class)]
+#[UsesClass(PatchOperationHandler::class)]
 #[UsesClass(AddHandler::class)]
 #[UsesClass(CopyHandler::class)]
 #[UsesClass(MoveHandler::class)]

--- a/tests/exceptions/UnknownPathExceptionTest.php
+++ b/tests/exceptions/UnknownPathExceptionTest.php
@@ -13,13 +13,13 @@ use blancks\JsonPatch\json\accessors\ValueAccessorAwareTrait;
 use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\Add;
-use blancks\JsonPatch\operations\Copy;
-use blancks\JsonPatch\operations\Move;
+use blancks\JsonPatch\operations\handlers\AddHandler;
+use blancks\JsonPatch\operations\handlers\CopyHandler;
+use blancks\JsonPatch\operations\handlers\MoveHandler;
+use blancks\JsonPatch\operations\handlers\RemoveHandler;
+use blancks\JsonPatch\operations\handlers\ReplaceHandler;
+use blancks\JsonPatch\operations\handlers\TestHandler;
 use blancks\JsonPatch\operations\PatchOperation;
-use blancks\JsonPatch\operations\Remove;
-use blancks\JsonPatch\operations\Replace;
-use blancks\JsonPatch\operations\Test;
 use blancks\JsonPatch\FastJsonPatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -39,12 +39,12 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(BasicJsonHandler::class)]
 #[UsesClass(JsonPointer6901::class)]
 #[UsesClass(PatchOperation::class)]
-#[UsesClass(Add::class)]
-#[UsesClass(Copy::class)]
-#[UsesClass(Move::class)]
-#[UsesClass(Remove::class)]
-#[UsesClass(Replace::class)]
-#[UsesClass(Test::class)]
+#[UsesClass(AddHandler::class)]
+#[UsesClass(CopyHandler::class)]
+#[UsesClass(MoveHandler::class)]
+#[UsesClass(RemoveHandler::class)]
+#[UsesClass(ReplaceHandler::class)]
+#[UsesClass(TestHandler::class)]
 final class UnknownPathExceptionTest extends TestCase
 {
     /**

--- a/tests/operations/handlers/AddTest.php
+++ b/tests/operations/handlers/AddTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatchTest\operations;
+namespace blancks\JsonPatchTest\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FastJsonPatchExceptionTrait;
 use blancks\JsonPatch\exceptions\InvalidPatchValueException;
@@ -14,14 +14,14 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\Add;
+use blancks\JsonPatch\operations\handlers\AddHandler;
 use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Add::class)]
+#[CoversClass(AddHandler::class)]
 #[CoversClass(PatchOperation::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
@@ -38,7 +38,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(InvalidPatchValueException::class)]
 class AddTest extends TestCase
 {
-    private Add $Operation;
+    private AddHandler $Operation;
 
     protected function setUp(): void
     {
@@ -46,7 +46,7 @@ class AddTest extends TestCase
         $JsonPointerHandler = new JsonPointer6901;
         $JsonHandler->setJsonPointerHandler($JsonPointerHandler);
 
-        $this->Operation = new Add();
+        $this->Operation = new AddHandler();
         $this->Operation->setJsonHandler($JsonHandler);
         $this->Operation->setJsonPointerHandler($JsonPointerHandler);
     }

--- a/tests/operations/handlers/AddTest.php
+++ b/tests/operations/handlers/AddTest.php
@@ -15,14 +15,14 @@ use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
 use blancks\JsonPatch\operations\handlers\AddHandler;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(AddHandler::class)]
-#[CoversClass(PatchOperation::class)]
+#[CoversClass(PatchOperationHandler::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]

--- a/tests/operations/handlers/CopyTest.php
+++ b/tests/operations/handlers/CopyTest.php
@@ -17,14 +17,14 @@ use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
 use blancks\JsonPatch\operations\handlers\CopyHandler;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(CopyHandler::class)]
-#[CoversClass(PatchOperation::class)]
+#[CoversClass(PatchOperationHandler::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]

--- a/tests/operations/handlers/CopyTest.php
+++ b/tests/operations/handlers/CopyTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatchTest\operations;
+namespace blancks\JsonPatchTest\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FastJsonPatchExceptionTrait;
 use blancks\JsonPatch\exceptions\InvalidPatchFromException;
@@ -16,14 +16,14 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\Copy;
+use blancks\JsonPatch\operations\handlers\CopyHandler;
 use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Copy::class)]
+#[CoversClass(CopyHandler::class)]
 #[CoversClass(PatchOperation::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
@@ -42,7 +42,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(UnknownPathException::class)]
 class CopyTest extends TestCase
 {
-    private Copy $Operation;
+    private CopyHandler $Operation;
 
     protected function setUp(): void
     {
@@ -50,7 +50,7 @@ class CopyTest extends TestCase
         $JsonPointerHandler = new JsonPointer6901;
         $JsonHandler->setJsonPointerHandler($JsonPointerHandler);
 
-        $this->Operation = new Copy();
+        $this->Operation = new CopyHandler();
         $this->Operation->setJsonHandler($JsonHandler);
         $this->Operation->setJsonPointerHandler($JsonPointerHandler);
     }

--- a/tests/operations/handlers/MoveTest.php
+++ b/tests/operations/handlers/MoveTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatchTest\operations;
+namespace blancks\JsonPatchTest\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FastJsonPatchExceptionTrait;
 use blancks\JsonPatch\exceptions\InvalidPatchFromException;
@@ -16,14 +16,14 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
-use blancks\JsonPatch\operations\Move;
+use blancks\JsonPatch\operations\handlers\MoveHandler;
 use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Move::class)]
+#[CoversClass(MoveHandler::class)]
 #[CoversClass(PatchOperation::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
@@ -42,7 +42,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(UnknownPathException::class)]
 class MoveTest extends TestCase
 {
-    private Move $Operation;
+    private MoveHandler $Operation;
 
     protected function setUp(): void
     {
@@ -50,7 +50,7 @@ class MoveTest extends TestCase
         $JsonPointerHandler = new JsonPointer6901;
         $JsonHandler->setJsonPointerHandler($JsonPointerHandler);
 
-        $this->Operation = new Move();
+        $this->Operation = new MoveHandler();
         $this->Operation->setJsonHandler($JsonHandler);
         $this->Operation->setJsonPointerHandler($JsonPointerHandler);
     }

--- a/tests/operations/handlers/MoveTest.php
+++ b/tests/operations/handlers/MoveTest.php
@@ -17,14 +17,14 @@ use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
 use blancks\JsonPatch\operations\handlers\MoveHandler;
-use blancks\JsonPatch\operations\PatchOperation;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(MoveHandler::class)]
-#[CoversClass(PatchOperation::class)]
+#[CoversClass(PatchOperationHandler::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]

--- a/tests/operations/handlers/RemoveTest.php
+++ b/tests/operations/handlers/RemoveTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatchTest\operations;
+namespace blancks\JsonPatchTest\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FastJsonPatchExceptionTrait;
 use blancks\JsonPatch\exceptions\InvalidPatchFromException;
@@ -16,14 +16,14 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
+use blancks\JsonPatch\operations\handlers\RemoveHandler;
 use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
-use blancks\JsonPatch\operations\Remove;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Remove::class)]
+#[CoversClass(RemoveHandler::class)]
 #[CoversClass(PatchOperation::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
@@ -42,7 +42,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(UnknownPathException::class)]
 class RemoveTest extends TestCase
 {
-    private Remove $Operation;
+    private RemoveHandler $Operation;
 
     protected function setUp(): void
     {
@@ -50,7 +50,7 @@ class RemoveTest extends TestCase
         $JsonPointerHandler = new JsonPointer6901;
         $JsonHandler->setJsonPointerHandler($JsonPointerHandler);
 
-        $this->Operation = new Remove();
+        $this->Operation = new RemoveHandler();
         $this->Operation->setJsonHandler($JsonHandler);
         $this->Operation->setJsonPointerHandler($JsonPointerHandler);
     }

--- a/tests/operations/handlers/RemoveTest.php
+++ b/tests/operations/handlers/RemoveTest.php
@@ -16,15 +16,15 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\handlers\RemoveHandler;
-use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(RemoveHandler::class)]
-#[CoversClass(PatchOperation::class)]
+#[CoversClass(PatchOperationHandler::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]

--- a/tests/operations/handlers/ReplaceTest.php
+++ b/tests/operations/handlers/ReplaceTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatchTest\operations;
+namespace blancks\JsonPatchTest\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FastJsonPatchExceptionTrait;
 use blancks\JsonPatch\exceptions\InvalidPatchFromException;
@@ -17,14 +17,14 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
+use blancks\JsonPatch\operations\handlers\ReplaceHandler;
 use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
-use blancks\JsonPatch\operations\Replace;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Replace::class)]
+#[CoversClass(ReplaceHandler::class)]
 #[CoversClass(PatchOperation::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
@@ -44,7 +44,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(InvalidPatchValueException::class)]
 class ReplaceTest extends TestCase
 {
-    private Replace $Operation;
+    private ReplaceHandler $Operation;
 
     protected function setUp(): void
     {
@@ -52,7 +52,7 @@ class ReplaceTest extends TestCase
         $JsonPointerHandler = new JsonPointer6901;
         $JsonHandler->setJsonPointerHandler($JsonPointerHandler);
 
-        $this->Operation = new Replace();
+        $this->Operation = new ReplaceHandler();
         $this->Operation->setJsonHandler($JsonHandler);
         $this->Operation->setJsonPointerHandler($JsonPointerHandler);
     }

--- a/tests/operations/handlers/ReplaceTest.php
+++ b/tests/operations/handlers/ReplaceTest.php
@@ -17,15 +17,15 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\handlers\ReplaceHandler;
-use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ReplaceHandler::class)]
-#[CoversClass(PatchOperation::class)]
+#[CoversClass(PatchOperationHandler::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]

--- a/tests/operations/handlers/TestTest.php
+++ b/tests/operations/handlers/TestTest.php
@@ -17,15 +17,15 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
+use blancks\JsonPatch\operations\handlers\PatchOperationHandler;
 use blancks\JsonPatch\operations\handlers\TestHandler;
-use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(TestHandler::class)]
-#[CoversClass(PatchOperation::class)]
+#[CoversClass(PatchOperationHandler::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
 #[UsesClass(BasicJsonHandler::class)]

--- a/tests/operations/handlers/TestTest.php
+++ b/tests/operations/handlers/TestTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace blancks\JsonPatchTest\operations;
+namespace blancks\JsonPatchTest\operations\handlers;
 
 use blancks\JsonPatch\exceptions\FailedTestException;
 use blancks\JsonPatch\exceptions\InvalidPatchFromException;
@@ -17,14 +17,14 @@ use blancks\JsonPatch\json\crud\CrudTrait;
 use blancks\JsonPatch\json\handlers\BasicJsonHandler;
 use blancks\JsonPatch\json\handlers\JsonHandlerAwareTrait;
 use blancks\JsonPatch\json\pointer\JsonPointer6901;
+use blancks\JsonPatch\operations\handlers\TestHandler;
 use blancks\JsonPatch\operations\PatchOperation;
 use blancks\JsonPatch\operations\PatchValidationTrait;
-use blancks\JsonPatch\operations\Test;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Test::class)]
+#[CoversClass(TestHandler::class)]
 #[CoversClass(PatchOperation::class)]
 #[UsesClass(PatchValidationTrait::class)]
 #[UsesClass(CrudTrait::class)]
@@ -45,7 +45,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(FailedTestException::class)]
 class TestTest extends TestCase
 {
-    private Test $Operation;
+    private TestHandler $Operation;
 
     protected function setUp(): void
     {
@@ -53,7 +53,7 @@ class TestTest extends TestCase
         $JsonPointerHandler = new JsonPointer6901;
         $JsonHandler->setJsonPointerHandler($JsonPointerHandler);
 
-        $this->Operation = new Test();
+        $this->Operation = new TestHandler();
         $this->Operation->setJsonHandler($JsonHandler);
         $this->Operation->setJsonPointerHandler($JsonPointerHandler);
     }


### PR DESCRIPTION
This is a preparatory refactor for 3.0, ahead of implementing #12

We had so far only discussed renaming the concrete classes e.g. `Add => `AddHandler`, on the basis this should not affect end-users except in unusual cases.

Since we are now targeting this for a new major version, I have gone further than discussed and renamed all the classes, interfaces and methods related to patch operation handlers to include the `xxxHandler` suffix and moved them to an `operations/handlers` namespace.

I think this is best for consistency within the codebase, and avoiding any potential naming conflicts / confusion from #12.

However, it comes at the cost that any end-users who have implemented / registered custom handlers will need to do a little renaming before upgrading to 3.x. I'm not sure how common that's likely to be, and it should be an easy change to apply, but worth considering.

I've therefore split this into separate commits so I can easily limit to just renaming the concrete classes if preferred.