### PR TITLE
Refactor/bump min php version

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,10 +8,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up php 8.1
+      - name: Set up php 8.2
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
 
       - name: Install dependencies
         run: composer self-update && composer install && composer dump-autoload

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ["8.1"]
+        php-versions: ["8.2"]
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ["8.1", "8.2", "8.3", "8.4"]
+        php-versions: ["8.2", "8.3", "8.4", "8.5"]
 
     steps:
       - name: Checkout Code

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ vendor
 .phpunit.cache
 php_errors.log
 composer.lock
+.DS_Store
+coverage-report

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "lkrms/pretty-php": "^0.4.72"
     },
     "scripts": {
+        "coverage": "XDEBUG_MODE=coverage composer test -- --coverage-html coverage-report",
         "test": "phpunit",
         "static-analyse": "phpstan analyse --configuration phpstan.neon.dist",
         "pretty-php": "pretty-php src tests"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^10",


### PR DESCRIPTION
This pull request updates the project's PHP version compatibility and improves developer tooling. The main changes involve raising the minimum PHP version supported in CI workflows, updating the test matrix, and adding a new script for generating code coverage reports.

**CI/CD and PHP version updates:**

* Updated GitHub Actions workflows (`codecov.yml`, `phpstan.yml`, `test.yml`) to use PHP 8.2 as the minimum version, removing support for PHP 8.1 and adding support up to PHP 8.5 in the test matrix.

**Developer tooling:**

* Added a new `coverage` script to `composer.json` for generating HTML code coverage reports using Xdebug and PHPUnit.